### PR TITLE
Unified servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "seed-dev": "knex --knexfile=src/server/knexfile seed:run",
     "clean-db": "src/server/./cleandb.sh",
     "set-dev-db": "npm run clean-db; npm run migrations; npm run seed-dev",
-    "serve-dev": "nodemon src/server/app.js",
+    "start": "nodemon src/server/app.js",
     "dev-setup": "chmod +x setup.sh; ./setup.sh",
     "use-node-version": "nvm use",
     "build-watch": "webpack --watch --config webpack.config.js",
     "compile-sass": "sass --watch src/client/styles/sass:src/client/styles/css",
     "babel-transpile": "babel --watch src/client/app -d src/client/precompiled-dist",
     "build-babel": "babel src/client/app -d src/client/precompiled-dist",
-    "start": "concurrently --kill-others \"npm run babel-transpile\" \"npm run compile-sass\" \"npm run build-watch\" \"http-server src/client/ -p 9000\""
+    "serve-dev": "concurrently --kill-others \"npm run babel-transpile\" \"npm run compile-sass\" \"npm run build-watch\" \"npm run start\""
   },
   "repository": {
     "type": "git",
@@ -43,7 +43,6 @@
     "express": "^4.15.3",
     "file-loader": "^0.11.2",
     "font-awesome": "^4.7.0",
-    "http-server": "^0.10.0",
     "imports-loader": "^0.7.1",
     "jquery": "^3.2.1",
     "jquery-serializejson": "^2.8.1",

--- a/src/client/app/modules/connection.js
+++ b/src/client/app/modules/connection.js
@@ -1,12 +1,9 @@
 'use-strict'
 
-const SERVER = 'http://localhost';
-const PORT = '3000';
-const API = '/api/';
-const CONNECTION_STRING = `${SERVER}:${PORT}${API}`
 const axios = require('axios');
+const API = '/api/';
 const api = axios.create({
-  baseURL: CONNECTION_STRING,
+  baseURL: API,
   headers: {
     'Accept': 'application/json, application/xml, text/plain, text/html, *.*',
     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -28,6 +28,7 @@ app.use(invitationRoute(express));
 app.use(commentRoute(express));
 
 app.use('/api/*', response.afterGetRoute.bind(response));
+app.use('/', express.static('./src/client/'));
 
 app.listen(PORT, () => {
   console.log('Express running  on port: ' + PORT);


### PR DESCRIPTION
Hi team, just a simple improvement here to avoid using multiple servers when developing, now our express server is handling even public traffic. The only command we have to run to start up the application from now on is: `npm run serve-dev` and the whole application will be served on port 3000. Please also run `npm install` before testing this branch.

Thanks